### PR TITLE
chore: fix format check command

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,8 +28,8 @@ jobs:
         run: flutter pub get
 
       - name: Format
-        run: flutter format --dry-run --set-exit-if-changed .
-       
+        run: dart format -o none --set-exit-if-changed .
+
       - name: Analyze
         run: flutter analyze --no-pub
 


### PR DESCRIPTION
- In Flutter 3, the `flutter format` command was deprecated
- Add the correct `dart format` command