### PR TITLE
Fix impeller crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.1+1
+
+- Fix gradient border impeller bug
+
 ## 4.0.1
 
 - Upgrade lint pkg to v4.0.0

--- a/lib/src/border_painter.dart
+++ b/lib/src/border_painter.dart
@@ -25,7 +25,7 @@ class RectBorderPainter extends CustomPainter {
     RRect innerRRect = outerRRect.deflate(strokeWidth);
 
     // apply gradient shader
-    _paint.shader = gradient.createShader(outerRect);
+    _paint.shader = gradient.createShader(outerRect, textDirection: TextDirection.ltr);
 
     // create difference between outer and inner paths and draw it
     Path outer = Path()..addRRect(outerRRect);
@@ -64,7 +64,7 @@ class CircleBorderPainter extends CustomPainter {
     Rect innerCircle = outerCircle.deflate(strokeWidth);
 
     // apply gradient shader
-    _paint.shader = gradient.createShader(outerCircle);
+    _paint.shader = gradient.createShader(outerCircle, textDirection: TextDirection.ltr);
 
     // create difference between outer and inner paths and draw it
     Path outer = Path()..addOval(outerCircle);

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: glass_kit
 description: A package containing widgets to implement glass morphism in flutter apps.
-version: 4.0.1
+version: 4.0.1+1
 homepage: https://github.com/bharat-1809/glass_kit
 
 environment:


### PR DESCRIPTION
`Gradient.createShader` crash on Android when impeller engine is used (flutter default)

Fix is from issue https://github.com/flutter/flutter/issues/156660:

`textDirection: TextDirection.ltr` should be added to `createShader`
