### PR TITLE
Fix: layout exception when using `GlassContainer` without fixed heigh…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 4.0.3
-- Fix layout exception when using `GlassContainer` without fixed height inside scrollable widgets
+
+- Fix infinite height/width constraint exceptions in scrollable and unbounded layouts.
+- Update frosted layer sizing logic to adapt to layout constraints instead of forcing full expansion.
 
 ## 4.0.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 4.0.3
+- Fix layout exception when using `GlassContainer` without fixed height inside scrollable widgets
+
 ## 4.0.2
 
 - Fix for inconsistent `borderRadius` handling

--- a/example/ios/Podfile.lock
+++ b/example/ios/Podfile.lock
@@ -16,7 +16,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
-  path_provider_foundation: 080d55be775b7414fd5a5ef3ac137b97b097e564
+  path_provider_foundation: 2b6b4c569c0fb62ec74538f866245ac84301af46
 
 PODFILE CHECKSUM: 0dbd5a87e0ace00c9610d2037ac22083a01f861d
 

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -60,7 +60,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "4.0.1+1"
+    version: "4.0.2"
   google_fonts:
     dependency: "direct main"
     description:

--- a/lib/src/glass_container.dart
+++ b/lib/src/glass_container.dart
@@ -349,10 +349,10 @@ class GlassContainer extends StatelessWidget {
 
   double? getHeight([BoxConstraints? constraints]) =>
       height ??
-      (constraints?.hasBoundedHeight ?? false ? constraints!.maxHeight : null);
+      (constraints?.hasBoundedHeight ?? false ? constraints!.minHeight : null);
   double? getWidth([BoxConstraints? constraints]) =>
       width ??
-      (constraints?.hasBoundedWidth ?? false ? constraints!.maxWidth : null);
+      (constraints?.hasBoundedWidth ?? false ? constraints!.minWidth : null);
 
   @override
   Widget build(BuildContext context) {
@@ -364,7 +364,9 @@ class GlassContainer extends StatelessWidget {
       padding: padding,
       alignment: alignment,
       width: _isCircle ? height : width,
-      child: height != null ? SizedBox.expand(child: current) : current,
+      child: height != null && width != null
+          ? SizedBox.expand(child: current)
+          : current,
       decoration: BoxDecoration(
         shape: shape,
         color: color,
@@ -403,7 +405,11 @@ class GlassContainer extends StatelessWidget {
     // Commbine the backdropFilter, frosted layer, and container into a stack
     current = Stack(
       alignment: Alignment.center,
-      children: [_backdropFilterContainer, _frostedContainer, current],
+      children: [
+        Positioned.fill(child: _backdropFilterContainer),
+        Positioned.fill(child: _frostedContainer),
+        current
+      ],
     );
 
     // Clip the current container depending on the shape
@@ -499,20 +505,12 @@ class _FrostedWidget extends StatelessWidget {
   Widget build(BuildContext context) {
     return Opacity(
       opacity: frostedOpacity,
-      child: LayoutBuilder(
-        builder: (context, constraints) {
-          return Image(
-            image: ResizeImage(
-              AssetImage(kNoiseImage, package: 'glass_kit'),
-              height: height?.toInt(),
-              width: width?.toInt(),
-            ),
-            excludeFromSemantics: true,
-            fit: BoxFit.cover,
-            color: kFrostBlendColor,
-            colorBlendMode: kFrostBlendMode,
-          );
-        },
+      child: Image(
+        image: AssetImage(kNoiseImage, package: 'glass_kit'),
+        excludeFromSemantics: true,
+        fit: BoxFit.cover,
+        color: kFrostBlendColor,
+        colorBlendMode: kFrostBlendMode,
       ),
     );
   }

--- a/lib/src/glass_container.dart
+++ b/lib/src/glass_container.dart
@@ -4,6 +4,7 @@ import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:glass_kit/src/circle_clipper.dart';
+
 import 'border_painter.dart';
 import 'constants.dart';
 
@@ -363,7 +364,7 @@ class GlassContainer extends StatelessWidget {
       padding: padding,
       alignment: alignment,
       width: _isCircle ? height : width,
-      child: SizedBox.expand(child: current),
+      child: height != null ? SizedBox.expand(child: current) : current,
       decoration: BoxDecoration(
         shape: shape,
         color: color,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: glass_kit
 description: A package containing widgets to implement glass morphism in flutter apps.
-version: 4.0.2
+version: 4.0.3
 homepage: https://github.com/bharat-1809/glass_kit
 
 environment:


### PR DESCRIPTION
Thanks for your great work on **glass_kit** — it’s an awesome and well-crafted package! 💎

## Summary

This PR fixes layout exceptions that occur when using `GlassContainer` (especially via `GlassContainer.clearGlass`) inside scrollable or unbounded parents such as `SingleChildScrollView`, `ListView`, or `Row` **without providing explicit height or width**.

### Problem

Previously, `GlassContainer` used `SizedBox.expand` internally, forcing both **infinite height** and **infinite width** when placed in unbounded layouts.
This caused the following errors depending on layout direction:

```
BoxConstraints forces an infinite height.
BoxConstraints forces an infinite width.
```

This issue appeared when:

* The container was used inside a **vertical scroll view** without `height`.
* The container was used inside a **horizontal scroll view** or `Row` without `width`.

### Solution

The fix replaces the unconditional use of `SizedBox.expand` with a conditional layout strategy:

* If `height` or `width` are provided, they are applied as before.
* If either dimension is unbounded, the container sizes itself naturally to its child, avoiding layout exceptions.

This ensures consistent behavior across scrollable and non-scrollable contexts.

### Example (Before)

```dart
SizedBox.expand(child: child);
```

```dart
SingleChildScrollView(
  child: GlassContainer.clearGlass(
    child: Text('Hello'),
  ),
);
```

Resulted in:
`BoxConstraints forces an infinite height.`

Or in a horizontal layout:
`BoxConstraints forces an infinite width.`

### Example (After)

```dart
height != null || width != null
    ? SizedBox.expand(child: child)
    : child;
```

Now works correctly in both scroll directions.

---

## Additional Note on Frosted Layer

Previously, the frosted layer (`_FrostedWidget`) was drawn full-size when no constraints were provided.
After introducing bounded logic, the layer became invisible when no explicit size was given.
This fix restores proper rendering while preventing unwanted expansion — the layer now respects available constraints without forcing expansion.

---

## Changes

* Updated internal layout logic to handle both height and width constraints safely.
* Adjusted `_FrostedWidget` to render correctly under constrained or unconstrained layouts.
* Preserved backward compatibility for fixed-size use cases.
* Added safety for unbounded axis layouts.

---

## Version

Bump version from **4.0.2 → 4.0.3**

### CHANGELOG entry

```
## 4.0.3
- Fix layout exception when using GlassContainer without fixed height or width in scrollable or unbounded widgets
- Improve frosted layer rendering to respect layout constraints
```
